### PR TITLE
Upgrade bugsnag library from v2 to v3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d2wy8f7a9ursnm.cloudfront.net/bugsnag-2.min.js';
+var src = '//d2wy8f7a9ursnm.cloudfront.net/bugsnag-3.min.js';
 
 /**
  * Expose `Bugsnag` integration.


### PR DESCRIPTION
https://github.com/bugsnag/bugsnag-js/releases/tag/v3.0.0

> This release adds support for automatic and custom breadcrumb tracking.   Breadcrumbs replace the private implementation of "last event" tracking.  It also removes support for the deprecated userId setting, which has been replaced by the user object.
